### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rfc.yml
+++ b/.github/workflows/rfc.yml
@@ -6,6 +6,9 @@ on:
       - "rfc/**"
       - ".github/ISSUE_TEMPLATE/rfc_proposal.yml"
 
+permissions:
+  contents: read
+
 jobs:
   validate-rfc:
     name: "Validation des RFC"


### PR DESCRIPTION
Potential fix for [https://github.com/teremuhamblin/Android/security/code-scanning/1](https://github.com/teremuhamblin/Android/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege access unless overridden. For this workflow, `contents: read` is sufficient and aligns with CodeQL’s recommended minimal baseline.

Best single fix (no behavior change): in `.github/workflows/rfc.yml`, insert:

```yml
permissions:
  contents: read
```

directly after the `on:` block (or before `jobs:`). No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
